### PR TITLE
Fix spelling error in README.md: `manu` → `menu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you do not have an Okta account, please [sign up here](https://www.okta.com/d
    - Provide values for CLIENT_ID and CLIENT_SECRET, both obtained in step 4 above
    - Leave the values for SCOPES and REDIRECT_URI as-is
 7. Enable [CORS access](https://developer.okta.com/docs/api/getting_started/enabling_cors) to your Okta org
-   - In the navigation manu, select **API** then **Trusted Origins**
+   - In the navigation menu, select **API** then **Trusted Origins**
    - Click **Add Origin**
    - Set **Origin URL** = `http://localhost:8000` and check the box **CORS**
    - Save


### PR DESCRIPTION
I believe the github editor did a sneaky invisible change on the last line of the file. If this is a dealbreaker for this PR, I will try to get around to making a PR without that change at some later date.